### PR TITLE
Fix API error messages for /api/check-status endpoint based on Kong usage data

### DIFF
--- a/api/src/main/java/com/example/dummy_api/DummyController.java
+++ b/api/src/main/java/com/example/dummy_api/DummyController.java
@@ -30,19 +30,30 @@ public class DummyController {
     }
 
     @GetMapping("/check-status")
-    public String checkStatus(@RequestParam String status) {
-        // Validate input
-        if (!status.equals("Assigned") && !status.equals("Unassigned") && !status.equals("Unknown")) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+    public String checkStatus(@RequestParam(required = false) String status) {
+        // Check if status parameter is missing
+        if (status == null || status.trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Missing required parameter 'status'. Please provide a status parameter. " +
+                "Example: /api/check-status?status=Assigned. " +
+                "Allowed values: Assigned, Unassigned, Unknown");
         }
 
-        // Validate input
+        // Find matching enum status
         Status enumStatus = null;
         for (Status s : Status.values()) {
-            if (s.getStatus().equalsIgnoreCase(status)) {
+            if (s.getStatus().equalsIgnoreCase(status.trim())) {
                 enumStatus = s;
                 break;
             }
+        }
+
+        // If no matching status found, provide helpful error message
+        if (enumStatus == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Invalid status value '" + status + "'. " +
+                "Allowed values are: Assigned, Unassigned, Unknown. " +
+                "Values are case-insensitive.");
         }
 
         return "Received status: " + enumStatus.getStatus();


### PR DESCRIPTION
## Summary

Fixed poor error handling in `/api/check-status` endpoint based on analysis of Kong API Gateway usage data that showed 9 recent 400 errors from this endpoint.

### Analysis of Kong Data
- **Endpoint**: `/api/check-status` (GET requests)
- **Error Count**: 9 x 400 errors in the last 24 hours
- **Root Cause**: Users calling endpoint without required `status` parameter
- **Impact**: Poor user experience with generic "400 Bad Request" messages

### Root Causes Identified
1. **Missing Parameter Handling**: Users calling `GET /api/check-status` without `?status=` parameter
2. **Poor Error Messages**: Code threw `ResponseStatusException(HttpStatus.BAD_REQUEST)` with no helpful message
3. **Potential NPE**: Risk of NullPointerException when `enumStatus` is null
4. **No Input Sanitization**: Missing `.trim()` on user input

### Changes Made
✅ Made `status` parameter optional with proper validation  
✅ Added descriptive error message for missing parameter with example usage  
✅ Added helpful error message for invalid values with allowed options list  
✅ Added null safety check to prevent NPE  
✅ Added input trimming for better UX  
✅ All tests pass  

### Before/After Error Messages

**Before:**
```
400 Bad Request (no helpful message)
```

**After - Missing Parameter:**
```
400 Bad Request: Missing required parameter 'status'. Please provide a status parameter. 
Example: /api/check-status?status=Assigned. Allowed values: Assigned, Unassigned, Unknown
```

**After - Invalid Value:**
```  
400 Bad Request: Invalid status value 'invalid'. Allowed values are: Assigned, Unassigned, Unknown. 
Values are case-insensitive.
```

## Test Plan

- [x] Existing tests pass
- [x] Manual testing of missing parameter scenario  
- [x] Manual testing of invalid parameter values
- [x] Manual testing of valid parameters (Assigned, Unassigned, Unknown)
- [x] Case-insensitive testing
- [x] Whitespace handling testing

🤖 Generated with [Claude Code](https://claude.ai/code)